### PR TITLE
Updates for Log4J 2 upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -385,26 +385,6 @@
         </extensions>
     </build>
 
-    <repositories>
-        <repository>
-            <id>reficio</id>
-            <url>http://repo.reficio.org/maven/</url>
-        </repository>
-        <repository>
-            <id>eviware</id>
-            <url>http://www.eviware.com/repository/maven2/</url>
-        </repository>
-        <repository>
-            <id>jboss</id>
-            <url>https://repository.jboss.org/nexus/content/repositories/deprecated/</url>
-        </repository>
-        <repository>
-            <id>servicemix</id>
-            <url>http://svn.apache.org/repos/asf/servicemix/m2-repo/</url>
-        </repository>
-
-    </repositories>
-
     <profiles>
         <profile>
             <id>clover</id>

--- a/soap-client/pom.xml
+++ b/soap-client/pom.xml
@@ -34,9 +34,20 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-        </dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.17.0</version>
+          </dependency>        
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.17.0</version>
+        </dependency>           
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+            <version>2.17.0</version>
+        </dependency>     
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>

--- a/soap-legacy/pom.xml
+++ b/soap-legacy/pom.xml
@@ -51,17 +51,17 @@
         <dependency>
             <groupId>xmlbeans</groupId>
             <artifactId>xbean</artifactId>
-            <version>fixed-2.4.0</version>
+            <version>2.2.0</version>
         </dependency>
         <dependency>
             <groupId>xmlbeans</groupId>
             <artifactId>xbean_xpath</artifactId>
-            <version>2.4.0</version>
+            <version>2.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.xmlbeans</groupId>
             <artifactId>xmlbeans-xmlpublic</artifactId>
-            <version>2.5.0</version>
+            <version>2.6.0</version>
         </dependency>
         <dependency>
             <groupId>javax.xml</groupId>
@@ -71,12 +71,12 @@
         <dependency>
             <groupId>net.sf.saxon</groupId>
             <artifactId>saxon</artifactId>
-            <version>9.1.0.8</version>
+            <version>8.7</version>
         </dependency>
         <dependency>
             <groupId>net.sf.saxon</groupId>
             <artifactId>saxon-dom</artifactId>
-            <version>9.1.0.8</version>
+            <version>8.7</version>
         </dependency>
         <dependency>
             <groupId>wsrf</groupId>


### PR DESCRIPTION
Several changes to root and module pom.xml files to get minimal viable build against Log4J 2.

NOTE: JavaDoc generation and tests are failing.